### PR TITLE
Aggiunta di metodo alternativo per avviare il container attraverso docker-compose

### DIFF
--- a/docker-compose-readme.md
+++ b/docker-compose-readme.md
@@ -1,0 +1,11 @@
+# Bozza di instruzione per l'uso di docker-compose:
+
+## Installazione 
+su ubuntu via package manager:
+
+`sudo apt install docker docker-compose`
+
+## Uso
+- modificare al posto di "xxxPATHxxx" il percorso in cui si é scaricata la directory
+- per avviare il docker-compose ( se é giá avviato si riavvia ) fare su ubuntu `sudo docker-compose up -d`
+- per stoppare il docker-compose `sudo docker-compose down`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2"
+services: 
+  paradigmi-playground:
+    image: paradigmi/paradigmi
+    ports:
+      - 8888:8888
+    volumes:
+      - xxxPATHxxx/notebooks:/mnt/paradigmi
+    privileged: True
+    mem_limit: 512m   # opzionale


### PR DESCRIPTION
Ho testato il file docker-compose solo su ubuntu 20.04.
Per ora ho creato un file di istruzioni separato dal principale in modo che si possano apportare modifiche senza intaccarlo.